### PR TITLE
fix: decamutexon/decamutexoff

### DIFF
--- a/zephyr/platform/deca_port.c
+++ b/zephyr/platform/deca_port.c
@@ -9,14 +9,17 @@
 
 decaIrqStatus_t decamutexon(void)
 {
+	bool status = dw3000_hw_isr_is_rised();
 	dw3000_hw_interrupt_disable();
-	return 1;
+	return (decaIrqStatus_t)status;
 }
 
 void decamutexoff(decaIrqStatus_t s)
 {
-	// TODO?: s is not used
-	dw3000_hw_interrupt_enable();
+	if(s)
+	{
+		dw3000_hw_interrupt_enable();
+	}
 }
 
 void deca_sleep(unsigned int time_ms)

--- a/zephyr/platform/dw3000_hw.c
+++ b/zephyr/platform/dw3000_hw.c
@@ -103,6 +103,15 @@ int dw3000_hw_init_interrupt(void)
 	}
 }
 
+///@brief Get status of IRQ pin
+decaIrqStatus_t dw3000_hw_interrupt_get_status(void)
+{
+    if (conf.gpio_irq.port) {
+        return (decaIrqStatus_t)gpio_pin_get_dt(&conf.gpio_irq);
+    }
+	return 0;
+}
+
 void dw3000_hw_interrupt_enable(void)
 {
 	if (conf.gpio_irq.port) {

--- a/zephyr/platform/dw3000_hw.h
+++ b/zephyr/platform/dw3000_hw.h
@@ -1,6 +1,8 @@
 #ifndef DW3000_HW_H
 #define DW3000_HW_H
 
+#include <stdbool.h>
+
 typedef void (* dw3000_isr_cb)(void);
 
 int dw3000_hw_init(void);


### PR DESCRIPTION
This commit is about fixing the ported functions decamutexon() & decamutexoff() to take into account the current status of IRQ.